### PR TITLE
The Watchdog Guardian

### DIFF
--- a/src/main/java/org/example/fromkhadija/sprint7/watchdog.sh
+++ b/src/main/java/org/example/fromkhadija/sprint7/watchdog.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+JAR_PATH="/mnt/c/Users/Codeline Comp/IdeaProjects/Sprint7/out/artifacts/Sprint7_jar/weather.jar"
+
+LOG_FILE="/home/khadijaali/watchdog-task/watchdog.log"
+
+if pgrep -f "weather.jar" > /dev/null
+then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] weather.jar is running. All good." >> "$LOG_FILE"
+else
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] weather.jar is NOT running. Starting it now..." >> "$LOG_FILE"
+
+    nohup java -jar "$JAR_PATH" > /dev/null 2>&1 &
+fi


### PR DESCRIPTION
The Watchdog Guardian is a Linux-based automation project built using Bash scripting to supervise and maintain a Java weather application (weather.jar).

The application retrieves and logs Muscat weather updates every minute. To improve system reliability and ensure uninterrupted operation, a monitoring script called watchdog.sh was created to continuously check the application status and automatically restart it whenever it stops or crashes.

The script relies on Linux process management commands such as pgrep to detect whether the JAR process is active. If the process is not found, the application is relaunched in the background using nohup, while all monitoring activities are recorded in a timestamped watchdog.log file.

The project also uses cron scheduling to:
- Run the watchdog automatically after every system reboot
- Perform health checks every minute
- Recover the application automatically after failures
- Avoid launching duplicate instances of the application

Main Features:
- Java Application Monitoring
- Automatic Failure Recovery
- Bash Script Automation
- Cron-based Task Scheduling
- Timestamped Activity Logging
- Linux / WSL Support
- Background Process Management

Technologies:
- Java
- Bash Scripting
- Linux / WSL
- Cron Jobs
- IntelliJ IDEA